### PR TITLE
Handle multiple GPUs, avoid NVCC/GCC compiler warnings

### DIFF
--- a/data/small/test_spgemm.mtx
+++ b/data/small/test_spgemm.mtx
@@ -1,3 +1,4 @@
+%%MatrixMarket matrix coordinate pattern general
 4 4 8
 2 1
 3 1

--- a/graphblas/backend/cuda/descriptor.hpp
+++ b/graphblas/backend/cuda/descriptor.hpp
@@ -16,7 +16,7 @@ class Descriptor {
   // Descriptions of these default settings are in "graphblas/types.hpp"
   Descriptor() : desc_{ GrB_DEFAULT, GrB_DEFAULT, GrB_DEFAULT, GrB_DEFAULT,
     GrB_FIXEDROW, GrB_32, GrB_32, GrB_128, GrB_PUSHPULL, GrB_16, GrB_CUDA},
-    d_context_(mgpu::CreateCudaDevice(0)), ta_(0), tb_(0), mode_(""), split_(0),
+    d_context_(mgpu::CreateCudaDevice(cuda_device())), ta_(0), tb_(0), mode_(""), split_(0),
     enable_split_(0), niter_(0), max_niter_(0), directed_(0), timing_(0),
     transpose_(0), mtxinfo_(0), verbose_(0), mxvmode_(0), switchpoint_(0),
     lastmxv_(GrB_PUSHONLY), dirinfo_(0), struconly_(0), opreuse_(0),
@@ -62,6 +62,12 @@ class Descriptor {
  private:
   Info resize(size_t target, std::string field);
   Info clear(std::string field);
+
+  int cuda_device() {
+    int device;
+    CUDA_CALL(cudaGetDevice(&device));
+    return device;
+  }
 
  private:
   Desc_value desc_[GrB_NDESCFIELD];

--- a/graphblas/backend/cuda/operations.hpp
+++ b/graphblas/backend/cuda/operations.hpp
@@ -41,6 +41,7 @@ Info mxm(Matrix<c>*       C,
         &B->sparse_, desc));
   } else {
     std::cout << "Error: SpMM and GEMM not implemented yet!\n";
+    return GrB_NOT_IMPLEMENTED;
     /*CHECK( C->setStorage( GrB_DENSE ) );
     if( A_mat_type==GrB_SPARSE && B_mat_type==GrB_DENSE )
     {
@@ -147,12 +148,13 @@ Info vxm(Vector<W>*       w,
         lb_mode == GrB_LOAD_BALANCE_TWC) {
       CHECK(w->setStorage(GrB_DENSE));
       // 1a) Simple SpMSpV no load-balancing codepath
-      if (lb_mode == GrB_LOAD_BALANCE_SIMPLE)
+      if (lb_mode == GrB_LOAD_BALANCE_SIMPLE) {
         std::cout << "Simple SPMSPV not implemented yet!\n";
+        return GrB_NOT_IMPLEMENTED;
         // CHECK( spmspvSimple(&w->dense_, mask, accum, op, &A->sparse_,
         //     &u->sparse_, desc) );
       // 1b) Thread-warp-block (single kernel) codepath
-      else if (lb_mode == GrB_LOAD_BALANCE_TWC)
+      } else if (lb_mode == GrB_LOAD_BALANCE_TWC)
         std::cout << "Error: B40C load-balance algorithm not implemented yet!\n";
       if (desc->debug()) {
         CHECK(w->getStorage(&u_vec_type));
@@ -267,13 +269,16 @@ Info mxv(Vector<W>*       w,
         lb_mode == GrB_LOAD_BALANCE_TWC) {
       CHECK(w->setStorage(GrB_DENSE));
       // 1a) Simple SpMSpV no load-balancing codepath
-      if (lb_mode == GrB_LOAD_BALANCE_SIMPLE)
+      if (lb_mode == GrB_LOAD_BALANCE_SIMPLE) {
         std::cout << "Simple SPMSPV not implemented yet!\n";
+        return GrB_NOT_IMPLEMENTED;
         // CHECK( spmspvSimple(&w->dense_, mask, accum, op, &A->sparse_,
         //     &u->sparse_, desc) );
       // 1b) Thread-warp-block (single kernel) codepath
-      else if (lb_mode == GrB_LOAD_BALANCE_TWC)
+      } else if (lb_mode == GrB_LOAD_BALANCE_TWC) {
         std::cout << "Error: B40C load-balance algorithm not implemented yet!\n";
+        return GrB_NOT_IMPLEMENTED;
+      }
       if (desc->debug()) {
         CHECK(w->getStorage(&u_vec_type));
         std::cout << "w_vec_type: " << u_vec_type << std::endl;
@@ -398,6 +403,7 @@ Info eWiseMult(Matrix<c>*       C,
                Descriptor*      desc) {
   // Use either op->operator() or op->mul() as the case may be
   std::cout << "Error: eWiseMult matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -424,11 +430,13 @@ Info eWiseMult(Matrix<c>*       C,
   if (A_mat_type == GrB_DENSE) {
     std::cout << "eWiseMult Dense Matrix Broadcast Scalar\n";
     std::cout << "Error: Feature not implemented yet!\n";
+    return GrB_NOT_IMPLEMENTED;
   } else if (A_mat_type == GrB_SPARSE) {
     // depending on whether mask is present or not
     if (mask != NULL) {
       std::cout << "eWiseMult Sparse Matrix Broadcast Scalar with Mask\n";
       std::cout << "Error: Feature not implemented yet!\n";
+      return GrB_NOT_IMPLEMENTED;
     } else {
       CHECK(C->setStorage(GrB_SPARSE));
       CHECK(eWiseMultInner(&C->sparse_, mask, accum, op, &A->sparse_,
@@ -481,16 +489,19 @@ Info eWiseMult(Matrix<c>*       C,
     if (A_mat_type == GrB_DENSE) {
       std::cout << "eWiseMult Dense Matrix Broadcast Vector\n";
       std::cout << "Error: Feature not implemented yet!\n";
+      return GrB_NOT_IMPLEMENTED;
     } else if (A_mat_type == GrB_SPARSE) {
       // depending on whether mask is present or not
       if (mask != NULL) {
         std::cout << "eWiseMult Sparse Matrix Broadcast Vector with Mask\n";
         std::cout << "Error: Feature not implemented yet!\n";
+        return GrB_NOT_IMPLEMENTED;
       } else {
         CHECK(C->setStorage(GrB_SPARSE));
         if (B_vec_type == GrB_SPARSE) {
           std::cout << "eWiseMult Sparse Matrix Broadcast Sparse Vector\n";
           std::cout << "Error: Feature not implemented yet!\n";
+          return GrB_NOT_IMPLEMENTED;
         } else {
           CHECK(eWiseMultColInner(&C->sparse_, mask, accum, op, &A->sparse_,
               &B->dense_, desc));
@@ -505,16 +516,19 @@ Info eWiseMult(Matrix<c>*       C,
     if (A_mat_type == GrB_DENSE) {
       std::cout << "eWiseMult Dense Matrix Broadcast Vector\n";
       std::cout << "Error: Feature not implemented yet!\n";
+      return GrB_NOT_IMPLEMENTED;
     } else if (A_mat_type == GrB_SPARSE) {
       // depending on whether mask is present or not
       if (mask != NULL) {
         std::cout << "eWiseMult Sparse Matrix Broadcast Vector with Mask\n";
         std::cout << "Error: Feature not implemented yet!\n";
+        return GrB_NOT_IMPLEMENTED;
       } else {
         CHECK(C->setStorage(GrB_SPARSE));
         if (B_vec_type == GrB_SPARSE) {
           std::cout << "eWiseMult Sparse Matrix Broadcast Sparse Vector\n";
           std::cout << "Error: Feature not implemented yet!\n";
+          return GrB_NOT_IMPLEMENTED;
         } else {
           CHECK(eWiseMultRowInner(&C->sparse_, mask, accum, op, &A->sparse_,
               &B->dense_, desc));
@@ -610,6 +624,7 @@ Info eWiseAdd(Matrix<c>*       C,
               Descriptor*      desc) {
   // Use either op->operator() or op->add() as the case may be
   std::cout << "Error: eWiseAdd matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -639,6 +654,7 @@ Info eWiseAdd(Vector<W>*       w,
     if (mask != NULL) {
       std::cout << "eWiseAdd Dense Vector-Scalar with Mask\n";
       std::cout << "Error: Feature not implemented yet!\n";
+      return GrB_NOT_IMPLEMENTED;
     } else {
       CHECK(w->setStorage(GrB_DENSE));
       CHECK(eWiseAddInner(&w->dense_, mask, accum, op, &u->dense_,
@@ -648,6 +664,7 @@ Info eWiseAdd(Vector<W>*       w,
     if (mask != NULL) {
       std::cout << "eWiseAdd Sparse Vector-Scalar Mask\n";
       std::cout << "Error: Feature not implemented yet!\n";
+      return GrB_NOT_IMPLEMENTED;
     } else {
       CHECK(w->setStorage(GrB_DENSE));
       CHECK(eWiseAddInner(&w->dense_, mask, accum, op, &u->sparse_,
@@ -674,6 +691,7 @@ Info extract(Vector<W>*                w,
              Index                     nindices,
              Descriptor*               desc) {
   std::cout << "Error: extract vector variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 template <typename c, typename a, typename m,
@@ -688,6 +706,7 @@ Info extract(Matrix<c>*                C,
              Index                     ncols,
              Descriptor*               desc) {
   std::cout << "Error: extract matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 template <typename W, typename a, typename M,
@@ -701,6 +720,7 @@ Info extract(Vector<W>*                w,
              Index                     col_index,
              Descriptor*               desc) {
   std::cout << "Error: extract vector variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 template <typename W, typename U, typename M,
@@ -713,7 +733,7 @@ Info assign(Vector<W>*                w,
             Index                     nindices,
             Descriptor*               desc) {
   std::cout << "Error: assign vector variant not implemented yet!\n";
-  return GrB_SUCCESS;
+  return GrB_NOT_IMPLEMENTED;
 }
 
 template <typename c, typename a, typename m,
@@ -728,6 +748,7 @@ Info assign(Matrix<c>*                C,
             Index                     ncols,
             Descriptor*               desc) {
   std::cout << "Error: assign matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 template <typename c, typename U, typename M,
@@ -741,6 +762,7 @@ Info assign(Matrix<c>*                C,
             Index                     col_index,
             Descriptor*               desc) {
   std::cout << "Error: assign matrix column variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 template <typename c, typename U, typename M,
@@ -754,6 +776,7 @@ Info assign(Matrix<c>*                C,
             Index                     ncols,
             Descriptor*               desc) {
   std::cout << "Error: assign matrix row variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 template <typename W, typename T, typename M,
@@ -806,6 +829,7 @@ Info assign(Matrix<c>*                C,
             Index                     ncols,
             Descriptor*               desc) {
   std::cout << "Error: assign matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 template <typename W, typename U, typename M,
@@ -911,6 +935,7 @@ Info reduce(Vector<W>*       w,
       return GrB_UNINITIALIZED_OBJECT;
   } else {
     std::cout << "Error: Masked reduce not implemented yet!\n";
+    return GrB_NOT_IMPLEMENTED;
   }
 
   if (desc->debug()) {
@@ -978,6 +1003,7 @@ Info reduce(T*               val,
   } else if (mat_type == GrB_DENSE) {
     std::cout << "Error: reduce matrix-scalar for dense matrix\n";
     std::cout << "not implemented yet!\n";
+    return GrB_NOT_IMPLEMENTED;
     // CHECK(reduceInner(val, accum, op, &A->dense_, desc));
   } else {
     return GrB_UNINITIALIZED_OBJECT;
@@ -1000,6 +1026,7 @@ Info transpose(Matrix<c>*       C,
     std::cout << "===Begin transpose===\n";
   }
   std::cout << "Error: transpose not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 template <typename T, typename a, typename b,
@@ -1026,8 +1053,10 @@ Info traceMxmTranspose(T*               val,
   // 4) DeMat x SpMat
   if (A_mat_type == GrB_SPARSE && B_mat_type == GrB_SPARSE)
     CHECK(traceMxmTransposeInner(val, op, &A->sparse_, &B->sparse_, desc));
-  else
+  else {
     std::cout << "Error: Trace operator not implemented!\n";
+    return GrB_NOT_IMPLEMENTED;
+  }
 
   if (desc->debug()) {
     std::cout << "===End traceMxmTranspose===\n";
@@ -1169,13 +1198,16 @@ Info applyVxm(Vector<W>*       w,
         lb_mode == GrB_LOAD_BALANCE_TWC) {
       CHECK(w->setStorage(GrB_DENSE));
       // 1a) Simple SpMSpV no load-balancing codepath
-      if (lb_mode == GrB_LOAD_BALANCE_SIMPLE)
+      if (lb_mode == GrB_LOAD_BALANCE_SIMPLE){
         std::cout << "Simple SPMSPV not implemented yet!\n";
+        return GrB_NOT_IMPLEMENTED;
         // CHECK( spmspvSimple(&w->dense_, mask, accum, op, &A->sparse_,
         //     &u->sparse_, desc) );
       // 1b) Thread-warp-block (single kernel) codepath
-      else if (lb_mode == GrB_LOAD_BALANCE_TWC)
+      } else if (lb_mode == GrB_LOAD_BALANCE_TWC) {
         std::cout << "Error: B40C load-balance algorithm not implemented yet!\n";
+        return GrB_NOT_IMPLEMENTED;
+      }
       if (desc->debug()) {
         CHECK(w->getStorage(&u_vec_type));
         std::cout << "w_vec_type: " << u_vec_type << std::endl;

--- a/graphblas/backend/cuda/spmspv_inner.hpp
+++ b/graphblas/backend/cuda/spmspv_inner.hpp
@@ -98,10 +98,10 @@ Info spmspvApspieMerge(Index*       w_ind,
   int    size        = static_cast<float>(A_nvals)*desc->memusage()+1;
   void* d_temp_nvals = reinterpret_cast<void*>(w_ind);
   void* d_scan       = reinterpret_cast<void*>(w_val);
-  void* d_temp       = desc->d_buffer_+2*A_nrows*sizeof(Index);
+  void* d_temp       = static_cast<char*>(desc->d_buffer_)+2*A_nrows*sizeof(Index);
 
   if (desc->struconly())
-    d_scan = desc->d_buffer_+(A_nrows+size)*sizeof(Index);
+    d_scan = static_cast<char*>(desc->d_buffer_)+(A_nrows+size)*sizeof(Index);
 
   if (desc->debug()) {
     assert(*u_nvals <= A_nrows);
@@ -154,12 +154,12 @@ Info spmspvApspieMerge(Index*       w_ind,
   void* d_csrSwapVal;
 
   if (desc->struconly()) {
-    d_csrSwapInd = desc->d_buffer_+   A_nrows      *sizeof(Index);
-    d_temp       = desc->d_buffer_+(  A_nrows+size)*sizeof(Index);
+    d_csrSwapInd = static_cast<char*>(desc->d_buffer_)+   A_nrows      *sizeof(Index);
+    d_temp       = static_cast<char*>(desc->d_buffer_)+(  A_nrows+size)*sizeof(Index);
   } else {
-    d_csrSwapInd = desc->d_buffer_+ 2*A_nrows        *sizeof(Index);
-    d_csrSwapVal = desc->d_buffer_+(2*A_nrows+  size)*sizeof(Index);
-    d_temp       = desc->d_buffer_+(2*A_nrows+2*size)*sizeof(Index);
+    d_csrSwapInd = static_cast<char*>(desc->d_buffer_)+ 2*A_nrows        *sizeof(Index);
+    d_csrSwapVal = static_cast<char*>(desc->d_buffer_)+(2*A_nrows+  size)*sizeof(Index);
+    d_temp       = static_cast<char*>(desc->d_buffer_)+(2*A_nrows+2*size)*sizeof(Index);
   }
 
   if (!desc->struconly_) {
@@ -227,7 +227,7 @@ Info spmspvApspieMerge(Index*       w_ind,
 
   if (desc->struconly()) {
     if (desc->sort()) {
-      d_csrTempInd = desc->d_buffer_+(A_nrows+size)*sizeof(Index);
+      d_csrTempInd = static_cast<char*>(desc->d_buffer_)+(A_nrows+size)*sizeof(Index);
 
       if (!desc->split())
         CUDA_CALL(cub::DeviceRadixSort::SortKeys(NULL, temp_storage_bytes,
@@ -250,8 +250,8 @@ Info spmspvApspieMerge(Index*       w_ind,
             *w_nvals);
     }
   } else {
-    d_csrTempInd = desc->d_buffer_+(2*A_nrows+2*size)*sizeof(Index);
-    d_csrTempVal = desc->d_buffer_+(2*A_nrows+3*size)*sizeof(Index);
+    d_csrTempInd = static_cast<char*>(desc->d_buffer_)+(2*A_nrows+2*size)*sizeof(Index);
+    d_csrTempVal = static_cast<char*>(desc->d_buffer_)+(2*A_nrows+3*size)*sizeof(Index);
 
     if (!desc->split())
       CUDA_CALL(cub::DeviceRadixSort::SortPairs(NULL, temp_storage_bytes,

--- a/graphblas/operations.hpp
+++ b/graphblas/operations.hpp
@@ -315,6 +315,7 @@ Info eWiseAdd(Matrix<c>*       C,
               Descriptor*      desc) {
   // Use either op->operator() or op->add() as the case may be
   std::cout << "Error: eWiseAdd matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -366,6 +367,7 @@ Info extract(Vector<W>*                w,
              Index                     nindices,
              Descriptor*               desc) {
   std::cout << "Error: extract vector variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -385,6 +387,7 @@ Info extract(Matrix<c>*                C,
              Index                     ncols,
              Descriptor*               desc) {
   std::cout << "Error: extract matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -403,6 +406,7 @@ Info extract(Vector<W>*                w,
              Index                     col_index,
              Descriptor*               desc) {
   std::cout << "Error: extract matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -420,6 +424,7 @@ Info assign(Vector<W>*                w,
             Index                     nindices,
             Descriptor*               desc) {
   std::cout << "Error: assign vector variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -440,6 +445,7 @@ Info assign(Matrix<c>*                C,
             Index                     ncols,
             Descriptor*               desc) {
   std::cout << "Error: assign matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -459,6 +465,7 @@ Info assign(Matrix<c>*                C,
             Index                     col_index,
             Descriptor*               desc) {
   std::cout << "Error: assign matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -478,6 +485,7 @@ Info assign(Matrix<c>*                C,
             Index                     ncols,
             Descriptor*               desc) {
   std::cout << "Error: assign matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -527,6 +535,7 @@ Info assign(Matrix<c>*                C,
             Index                     ncols,
             Descriptor*               desc) {
   std::cout << "Error: assign matrix variant not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -664,6 +673,7 @@ Info transpose(Matrix<c>*       C,
                const Matrix<a>* A,
                Descriptor*      desc) {
   std::cout << "Error: transpose not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -699,6 +709,7 @@ Info scale(Matrix<b>*       B,
            T                val,
            Descriptor*      desc) {
   std::cout << "Error: scale not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!
@@ -713,6 +724,7 @@ Info scale(Vector<W>*       w,
            T                val,
            Descriptor*      desc) {
   std::cout << "Error: scale not implemented yet!\n";
+  return GrB_NOT_IMPLEMENTED;
 }
 
 /*!

--- a/graphblas/types.hpp
+++ b/graphblas/types.hpp
@@ -34,6 +34,7 @@ enum Info {GrB_SUCCESS,
            GrB_DIMENSION_MISMATCH,
            GrB_OUTPUT_NOT_EMPTY,
            GrB_NO_VALUE,
+           GrB_NOT_IMPLEMENTED,
            GrB_OUT_OF_MEMORY,         // Execution errors
            GrB_INSUFFICIENT_SPACE,
            GrB_INVALID_OBJECT,

--- a/test/gspgemm.cu
+++ b/test/gspgemm.cu
@@ -41,7 +41,7 @@ int main( int argc, char** argv )
       dat_name);
   if(DEBUG) b.print();
 
-  // // Multiply
+  //
   graphblas::Matrix<float> c(a_num_rows, b_num_cols);
   graphblas::Descriptor desc;
   desc.descriptor_.debug_ = true;
@@ -56,6 +56,31 @@ int main( int argc, char** argv )
   );
   if(DEBUG) c.print();
 
+  // Multiply using gpu array initialization
+  graphblas::Matrix<float> A(a_num_rows, a_num_cols);
+  graphblas::Matrix<float> B(b_num_rows, b_num_cols);
+  graphblas::Matrix<float> C(a_num_rows, b_num_cols);
+
+  A.build(a.matrix_.sparse_.d_csrRowPtr_, a.matrix_.sparse_.d_csrColInd_, a.matrix_.sparse_.d_csrVal_, a.matrix_.sparse_.nvals_);
+  B.build(b.matrix_.sparse_.d_csrRowPtr_, b.matrix_.sparse_.d_csrColInd_, b.matrix_.sparse_.d_csrVal_, b.matrix_.sparse_.nvals_);
+
+  desc.descriptor_.debug_ = true;
+
+  graphblas::mxm<T, T, T, T>(&C, GrB_NULL, GrB_NULL, graphblas::PlusMultipliesSemiring<float>(),
+                             &A, &B, &desc);
+
+  // Multiply using gpu array initialization
+  graphblas::Matrix<float> a_(a_num_rows, a_num_cols);
+  graphblas::Matrix<float> b_(b_num_rows, b_num_cols);
+  graphblas::Matrix<float> c_(a_num_rows, b_num_cols);
+
+  a_.build(a.matrix_.sparse_.h_csrRowPtr_, a.matrix_.sparse_.h_csrColInd_, a.matrix_.sparse_.h_csrVal_, a.matrix_.sparse_.nvals_);
+  b_.build(b.matrix_.sparse_.h_csrRowPtr_, b.matrix_.sparse_.h_csrColInd_, b.matrix_.sparse_.h_csrVal_, b.matrix_.sparse_.nvals_);
+
+  desc.descriptor_.debug_ = true;
+
+  graphblas::mxm<T, T, T, T>(&c_, GrB_NULL, GrB_NULL, graphblas::PlusMultipliesSemiring<float>(),
+                             &a_, &b_, &desc);
 
   std::cout << "done" << std::endl;
 }


### PR DESCRIPTION
Descriptors now create a moderngpu context on the current device, instead of always using device 0.

Added GrB_NOT_IMPLEMENTED and added a number of missing return statements.